### PR TITLE
Fix formatting of ProviderID

### DIFF
--- a/pkg/managers/vm/machine_scope.go
+++ b/pkg/managers/vm/machine_scope.go
@@ -46,6 +46,8 @@ const (
 	podNetworkName                    = "pod-network"
 )
 
+const providerIDFormat = "kubevirt://%s/%s"
+
 type machineScope struct {
 	infraClusterClient    infracluster.Client
 	tenantClusterClient   tenantcluster.Client
@@ -186,7 +188,7 @@ func (s *machineScope) setProviderID(vm *kubevirtapiv1.VirtualMachine) {
 		return
 	}
 
-	providerID := fmt.Sprintf("kubevirt:///%s/%s", s.getMachineNamespace(), vm.GetName())
+	providerID := formatProviderID(s.getMachineNamespace(), vm.GetName())
 
 	if existingProviderID != nil && *existingProviderID == providerID {
 		klog.Infof("%s: ProviderID already set in the machine Spec with value:%s", s.getMachineName(), *existingProviderID)
@@ -499,4 +501,8 @@ func (s *machineScope) setProviderStatus(vm *kubevirtapiv1.VirtualMachine, vmi *
 // GetMachineName return the name of the provided Machine
 func GetMachineName(machine *machinev1.Machine) string {
 	return machine.GetName()
+}
+
+func formatProviderID(namespace, name string) string {
+	return fmt.Sprintf(providerIDFormat, namespace, name)
 }

--- a/pkg/managers/vm/vm_test.go
+++ b/pkg/managers/vm/vm_test.go
@@ -397,7 +397,7 @@ func TestUpdate(t *testing.T) {
 			clientUpdateVMError:    nil,
 			emptyGetVM:             false,
 			labels:                 nil,
-			providerID:             fmt.Sprintf("kubevirt:///%s/%s", defaultNamespace, mahcineName),
+			providerID:             formatProviderID(defaultNamespace, mahcineName),
 			wantVMToBeReady:        true,
 		},
 		{
@@ -408,7 +408,7 @@ func TestUpdate(t *testing.T) {
 			clientUpdateVMError:             nil,
 			emptyGetVM:                      false,
 			labels:                          nil,
-			providerID:                      fmt.Sprintf("kubevirt:///%s/%s", defaultNamespace, mahcineName),
+			providerID:                      formatProviderID(defaultNamespace, mahcineName),
 			wantVMToBeReady:                 true,
 			useDefaultCredentialsSecretName: true,
 		},
@@ -538,7 +538,6 @@ func TestUpdate(t *testing.T) {
 				assert.Equal(t, err.Error(), "requeue in: 20s")
 			} else {
 				assert.Equal(t, err, nil)
-				//providerID := fmt.Sprintf("kubevirt:///%s/%s", machineScope.machine.GetNamespace(), machineScope.virtualMachine.GetName())
 				assert.Equal(t, *machine.Spec.ProviderID, tc.providerID)
 			}
 		})


### PR DESCRIPTION
- the provider ID format seem to have extra `/` in it `kubevirt:///` 
- extract all usage of the format to a function 