### PR TITLE
Update dockerfile to rhel8 and use latest build artifacts

### DIFF
--- a/Dockerfile.rhel
+++ b/Dockerfile.rhel
@@ -1,9 +1,9 @@
-FROM registry.svc.ci.openshift.org/ocp/builder:golang-1.13 AS builder
+FROM registry.svc.ci.openshift.org/ocp/builder:rhel-8-golang-1.15-openshift-4.6 AS builder
 WORKDIR /go/src/github.com/kubevirt/cluster-api-provider-kubevirt
 COPY . .
 # VERSION env gets set in the openshift/release image and refers to the golang version, which interfers with our own
 RUN unset VERSION \
  && GOPROXY=off NO_DOCKER=1 make build
 
-FROM registry.svc.ci.openshift.org/ocp/4.0:base
+FROM registry.svc.ci.openshift.org/ocp/4.6:base
 COPY --from=builder /go/src/github.com/kubevirt/cluster-api-provider-kubevirt/bin/machine-controller-manager /


### PR DESCRIPTION
- use latest builder image for 4.6
- rename file to match the CI definition (now Dockerfile.rhel)