### PR TITLE
Fixing kubevirt-credentials key name to be kubeconfig

### DIFF
--- a/pkg/clients/infracluster/client.go
+++ b/pkg/clients/infracluster/client.go
@@ -32,7 +32,7 @@ import (
 
 const (
 	// platformCredentialsKey is secret key containing kubeconfig content of the infra-cluster
-	platformCredentialsKey                  = "userData"
+	platformCredentialsKey                  = "kubeconfig"
 	defaultCredentialsSecretSecretName      = "kubevirt-credentials"
 	defaultCredentialsSecretSecretNamespace = "openshift-machine-api"
 )


### PR DESCRIPTION
@nirarg @chenyosef 