### PR TITLE
WIP: Fix node deleted on provider flow

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -40,6 +40,7 @@ var (
 	leaseDuration = 120 * time.Second
 	renewDeadline = 110 * time.Second
 	retryPeriod   = 20 * time.Second
+	syncPeriod    = 10 * time.Minute
 )
 
 func main() {
@@ -101,6 +102,7 @@ func main() {
 		LeaseDuration:           leaderElectLeaseDuration,
 		MetricsBindAddress:      *metricsAddr,
 		HealthProbeBindAddress:  *healthAddr,
+		SyncPeriod:              &syncPeriod,
 		RetryPeriod:             &retryPeriod,
 		RenewDeadline:           &renewDeadline,
 	}


### PR DESCRIPTION
When a node is deleted in the provider we are responsible for removing the node from OCP and reflecting.
This PR added a couple of changes to make this work
1. Add logic to check if a VM exist on the provider (in the prociderIDController) - remove the node if the VM doesn't exist
2. Add logic to check if a VM is down(not ready) and requeue the reconcile for 1 min to check if the VM has been removed:
This is needed because a shutdown on a VM will trigger a reconcile on the controller (there is an event) but if the VM is removed there is no event there will be no reconcile on the node object
3. Add a sync time to the machine object
The machine API assumes that all machines will get reconciled every 10m, this also will move the machine into failed state if the node has been removed
