### PR TITLE
Fix Create and Update operation to get vmi only if vm's status is ready

### DIFF
--- a/pkg/kubevirt/mock/kubevirt_generated.go
+++ b/pkg/kubevirt/mock/kubevirt_generated.go
@@ -34,11 +34,12 @@ func (m *MockKubevirtVM) EXPECT() *MockKubevirtVMMockRecorder {
 }
 
 // Create mocks base method
-func (m *MockKubevirtVM) Create(machineScope machinescope.MachineScope, userData []byte) error {
+func (m *MockKubevirtVM) Create(machineScope machinescope.MachineScope, userData []byte) (bool, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Create", machineScope, userData)
-	ret0, _ := ret[0].(error)
-	return ret0
+	ret0, _ := ret[0].(bool)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
 }
 
 // Create indicates an expected call of Create
@@ -62,12 +63,13 @@ func (mr *MockKubevirtVMMockRecorder) Delete(machineScope interface{}) *gomock.C
 }
 
 // Update mocks base method
-func (m *MockKubevirtVM) Update(machineScope machinescope.MachineScope) (bool, error) {
+func (m *MockKubevirtVM) Update(machineScope machinescope.MachineScope) (bool, bool, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Update", machineScope)
 	ret0, _ := ret[0].(bool)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
+	ret1, _ := ret[1].(bool)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
 }
 
 // Update indicates an expected call of Update

--- a/pkg/machinescope/machine_scope.go
+++ b/pkg/machinescope/machine_scope.go
@@ -52,7 +52,7 @@ type MachineScope interface {
 	// SyncMachine update the Machine status, base of provided VirtualMachine and VirtualMachineInstance
 	// The following information is synced:
 	// ProviderID, Annotations, Labels, NetworkAddresses, ProviderStatus
-	SyncMachine(vm kubevirtapiv1.VirtualMachine, vmi kubevirtapiv1.VirtualMachineInstance, providerID string) error
+	SyncMachine(vm kubevirtapiv1.VirtualMachine, vmi *kubevirtapiv1.VirtualMachineInstance, providerID string) error
 	// CreateVirtualMachineFromMachine builds *kubevirtapiv1.VirtualMachine struct, based on the data saved in the Machine
 	CreateVirtualMachineFromMachine() (*kubevirtapiv1.VirtualMachine, error)
 	// GetMachine returns *machinev1.Machine struct saved in this MachineScope
@@ -338,10 +338,12 @@ func buildBootVolumeDataVolumeTemplate(virtualMachineName, pvcName, dvNamespace,
 	}
 }
 
-func (s *machineScope) SyncMachine(vm kubevirtapiv1.VirtualMachine, vmi kubevirtapiv1.VirtualMachineInstance, providerID string) error {
+func (s *machineScope) SyncMachine(vm kubevirtapiv1.VirtualMachine, vmi *kubevirtapiv1.VirtualMachineInstance, providerID string) error {
 	s.syncProviderID(vm, providerID)
 	s.syncMachineAnnotationsAndLabels(vm)
-	s.syncNetworkAddresses(vmi)
+	if vmi != nil {
+		s.syncNetworkAddresses(*vmi)
+	}
 	return s.syncProviderStatus(vm)
 }
 

--- a/pkg/machinescope/machine_scope_test.go
+++ b/pkg/machinescope/machine_scope_test.go
@@ -189,7 +189,7 @@ func TestSyncMachine(t *testing.T) {
 
 			expectedResultMachine := stubExpectedResultMachine(t, vm, vmi, providerID, machineType, tc.modifyExpectedMachine)
 
-			err := machineScope.SyncMachine(*vm, *vmi, providerID)
+			err := machineScope.SyncMachine(*vm, vmi, providerID)
 			if tc.expectedErr != "" {
 				assert.Error(t, err, tc.expectedErr)
 			} else {

--- a/pkg/machinescope/mock/machine_scope_generated.go
+++ b/pkg/machinescope/mock/machine_scope_generated.go
@@ -65,7 +65,7 @@ func (mr *MockMachineScopeMockRecorder) CreateIgnitionSecretFromMachine(userData
 }
 
 // SyncMachine mocks base method
-func (m *MockMachineScope) SyncMachine(vm v10.VirtualMachine, vmi v10.VirtualMachineInstance, providerID string) error {
+func (m *MockMachineScope) SyncMachine(vm v10.VirtualMachine, vmi *v10.VirtualMachineInstance, providerID string) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SyncMachine", vm, vmi, providerID)
 	ret0, _ := ret[0].(error)


### PR DESCRIPTION
This is done in order to avoid missliding error event after machine creation