### PR TITLE
Add SRIOV Support for Kubevirt Provider in machine-controller

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
-FROM registry.svc.ci.openshift.org/openshift/release:golang-1.13 AS builder
+FROM registry.ci.openshift.org/openshift/release:golang-1.16 AS builder
 WORKDIR /go/src/github.com/openshift/cluster-api-provider-kubevirt
 COPY . .
 # VERSION env gets set in the openshift/release image and refers to the golang version, which interfers with our own
 RUN unset VERSION \
  && GOPROXY=off NO_DOCKER=1 make build
 
-FROM registry.svc.ci.openshift.org/openshift/origin-v4.0:base
+FROM registry.ci.openshift.org/openshift/origin-v4.0:base
 COPY --from=builder /go/src/github.com/openshift/cluster-api-provider-kubevirt/bin/machine-controller-manager /

--- a/pkg/apis/kubevirtprovider/v1alpha1/types.go
+++ b/pkg/apis/kubevirtprovider/v1alpha1/types.go
@@ -35,6 +35,7 @@ type KubevirtMachineProviderSpec struct {
 	StorageClassName           string `json:"storageClassName,omitempty"`
 	IgnitionSecretName         string `json:"ignitionSecretName,omitempty"`
 	NetworkName                string `json:"networkName,omitempty"`
+	InterfaceBindingMethod     string `json:"interfaceBindingMethod,omitempty"`
 	PersistentVolumeAccessMode string `json:"persistentVolumeAccessMode,omitempty"`
 }
 

--- a/pkg/machinescope/machine_scope.go
+++ b/pkg/machinescope/machine_scope.go
@@ -158,6 +158,14 @@ func (s *machineScope) assertMandatoryParams() error {
 
 func (s *machineScope) buildVMITemplate(namespace string) *kubevirtapiv1.VirtualMachineInstanceTemplateSpec {
 	virtualMachineName := s.machine.GetName()
+	interfaceBindingMethod := kubevirtapiv1.InterfaceBindingMethod{
+		Bridge: &kubevirtapiv1.InterfaceBridge{},
+	}
+	if s.machineProviderSpec.InterfaceBindingMethod == "SRIOV" {
+		interfaceBindingMethod = kubevirtapiv1.InterfaceBindingMethod{
+			SRIOV: &kubevirtapiv1.InterfaceSRIOV{},
+		}
+	}
 
 	template := &kubevirtapiv1.VirtualMachineInstanceTemplateSpec{}
 
@@ -242,10 +250,8 @@ func (s *machineScope) buildVMITemplate(namespace string) *kubevirtapiv1.Virtual
 		},
 		Interfaces: []kubevirtapiv1.Interface{
 			{
-				Name: mainNetworkName,
-				InterfaceBindingMethod: kubevirtapiv1.InterfaceBindingMethod{
-					Bridge: &kubevirtapiv1.InterfaceBridge{},
-				},
+				Name:                   mainNetworkName,
+				InterfaceBindingMethod: interfaceBindingMethod,
 			},
 		},
 	}


### PR DESCRIPTION
Adding a new field for `KubevirtMachineProviderSpec type`, indicating the network type of the interfaces to be used by kubevirt machines that consist the tenant cluster, and using it instead of hard coding `Bridge: &kubevirtapiv1.InterfaceBridge{}`.

This PR is strictly related to another PR in openshift/installer: https://github.com/openshift/installer/pull/5088

Signed-off-by: orenc1 <ocohen@redhat.com>